### PR TITLE
Add support for Encoding AIS and MessagePack definitions

### DIFF
--- a/src/AisParser/AisMessage.cs
+++ b/src/AisParser/AisMessage.cs
@@ -23,5 +23,10 @@ namespace AisParser
             Repeat = payload.ReadUInt(6, 2);
             Mmsi = payload.ReadUInt(8, 30);
         }
+        public virtual void Encode(Payload payload)
+        {
+            payload.WriteUInt(Repeat, 2);
+            payload.WriteUInt(Mmsi, 30);
+        }
     }
 }

--- a/src/AisParser/AisMessage.cs
+++ b/src/AisParser/AisMessage.cs
@@ -1,9 +1,15 @@
+using MessagePack;
+
 namespace AisParser
 {
+    [MessagePackObject]
     public abstract class AisMessage
     {
+        [Key(0)]
         public AisMessageType MessageType { get; }
+        [Key(1)]
         public uint Repeat { get; set; }
+        [Key(2)]
         public uint Mmsi { get; set; }
 
         protected AisMessage(AisMessageType messageType)

--- a/src/AisParser/AisMessageFactory.cs
+++ b/src/AisParser/AisMessageFactory.cs
@@ -1,9 +1,24 @@
 using AisParser.Messages;
+using System;
 
 namespace AisParser
 {
     public class AisMessageFactory
     {
+        public Payload Encode<T>(T message) where T : AisMessage
+        {
+            Payload payload = new Payload();
+            switch (message)
+            {
+                case PositionReportClassAMessage t1:
+                    t1.Encode(payload);
+                    break;
+                default:
+                    return null;
+            }
+            return payload;
+        }
+
         public AisMessage Create(Payload payload)
         {
             switch (payload.MessageType)

--- a/src/AisParser/AisMessageFactory.cs
+++ b/src/AisParser/AisMessageFactory.cs
@@ -64,7 +64,8 @@ namespace AisParser
                 //TODO: 51
                 //TODO: 57
                 default:
-                    throw new AisMessageException($"Unrecognised message type: {payload.MessageType}");
+                    return null;
+                //    throw new AisMessageException($"Unrecognised message type: {payload.MessageType}");
             }
         }
     }

--- a/src/AisParser/AisParser.csproj
+++ b/src/AisParser/AisParser.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright Chris Richards</Copyright>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Authors>Chris Richards</Authors>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>AisParser</AssemblyName>
     <PackageId>AisParser</PackageId>
@@ -17,5 +17,10 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Version>1.0.0</Version>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MessagePack.ImmutableCollection" Version="1.8.74" />
+    <PackageReference Include="MessagePackAnalyzer" Version="1.8.74" />
+  </ItemGroup>
 
 </Project>

--- a/src/AisParser/AisParser.csproj
+++ b/src/AisParser/AisParser.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright Chris Richards</Copyright>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Authors>Chris Richards</Authors>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>net4.6.1</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>AisParser</AssemblyName>
     <PackageId>AisParser</PackageId>

--- a/src/AisParser/AisParser.csproj
+++ b/src/AisParser/AisParser.csproj
@@ -5,7 +5,7 @@
     <Copyright>Copyright Chris Richards</Copyright>
     <VersionPrefix>1.0.0</VersionPrefix>
     <Authors>Chris Richards</Authors>
-    <TargetFramework>net4.6.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>AisParser</AssemblyName>
     <PackageId>AisParser</PackageId>

--- a/src/AisParser/Messages/AddressedSafetyRelatedMessage.cs
+++ b/src/AisParser/Messages/AddressedSafetyRelatedMessage.cs
@@ -1,11 +1,19 @@
-﻿namespace AisParser.Messages
+﻿using MessagePack;
+
+namespace AisParser.Messages
 {
+    [MessagePackObject]
     public class AddressedSafetyRelatedMessage : AisMessage
     {
+        [Key(3)]
         public uint SequenceNumber { get; set; }
+        [Key(4)]
         public uint DestinationMmsi { get; set; }
+        [Key(5)]
         public bool RetransmitFlag { get; set; }
+        [Key(6)]
         public uint Spare { get; set; }
+        [Key(7)]
         public string Text { get; set; }
 
         public AddressedSafetyRelatedMessage()

--- a/src/AisParser/Messages/AidToNavigationReportMessage.cs
+++ b/src/AisParser/Messages/AidToNavigationReportMessage.cs
@@ -1,24 +1,44 @@
-﻿namespace AisParser.Messages
+﻿using MessagePack;
+namespace AisParser.Messages
 {
+    [MessagePackObject]
     public class AidToNavigationReportMessage : AisMessage
     {
+        [Key(3)]
         public NavigationalAidType NavigationalAidType { get; set; }
+        [Key(4)]
         public string Name { get; set; }
+        [Key(5)]
         public PositionAccuracy PositionAccuracy { get; set; }
+        [Key(6)]
         public double Longitude { get; set; }
+        [Key(7)]
         public double Latitude { get; set; }
+        [Key(8)]
         public uint DimensionToBow { get; set; }
+        [Key(9)]
         public uint DimensionToStern { get; set; }
+        [Key(10)]
         public uint DimensionToPort { get; set; }
+        [Key(11)]
         public uint DimensionToStarboard { get; set; }
+        [Key(12)]
         public PositionFixType PositionFixType { get; set; }
+        [Key(13)]
         public uint Timestamp { get; set; }
+        [Key(14)]
         public bool OffPosition { get; set; }
+        [Key(15)]
         public uint RegionalReserved { get; set; }
+        [Key(16)]
         public Raim Raim { get; set; }
+        [Key(17)]
         public bool VirtualAid { get; set; }
+        [Key(18)]
         public bool Assigned { get; set; }
+        [Key(19)]
         public uint Spare { get; set; }
+        [Key(20)]
         public string NameExtension { get; set; }
 
         public AidToNavigationReportMessage()

--- a/src/AisParser/Messages/BaseStationReportMessage.cs
+++ b/src/AisParser/Messages/BaseStationReportMessage.cs
@@ -1,19 +1,34 @@
-﻿namespace AisParser.Messages
+﻿using MessagePack;
+namespace AisParser.Messages
 {
+    [MessagePackObject]
     public class BaseStationReportMessage : AisMessage
     {
+        [Key(3)]
         public uint Year { get; set; }
+        [Key(4)]
         public uint Month { get; set; }
+        [Key(5)]
         public uint Day { get; set; }
+        [Key(6)]
         public uint Hour { get; set; }
+        [Key(7)]
         public uint Minute { get; set; }
+        [Key(8)]
         public uint Second { get; set; }
+        [Key(9)]
         public PositionAccuracy PositionAccuracy { get; set; }
+        [Key(10)]
         public double Longitude { get; set; }
+        [Key(11)]
         public double Latitude { get; set; }
+        [Key(12)]
         public PositionFixType PositionFixType { get; set; }
+        [Key(13)]
         public uint Spare { get; set; }
+        [Key(14)]
         public Raim Raim { get; set; }
+        [Key(15)]
         public uint RadioStatus { get; set; }
 
         public BaseStationReportMessage()

--- a/src/AisParser/Messages/BinaryAcknowledgeMessage.cs
+++ b/src/AisParser/Messages/BinaryAcknowledgeMessage.cs
@@ -1,15 +1,26 @@
-﻿namespace AisParser.Messages
+﻿using MessagePack;
+namespace AisParser.Messages
 {
+    [MessagePackObject]
     public class BinaryAcknowledgeMessage : AisMessage
     {
+        [Key(3)]
         public uint Spare { get; set; }
+        [Key(4)]
         public uint SequenceNumber1 { get; set; }
+        [Key(5)]
         public uint Mmsi1 { get; set; }
+        [Key(6)]
         public uint SequenceNumber2 { get; set; }
+        [Key(7)]
         public uint? Mmsi2 { get; set; }
+        [Key(8)]
         public uint SequenceNumber3 { get; set; }
+        [Key(9)]
         public uint? Mmsi3 { get; set; }
+        [Key(10)]
         public uint SequenceNumber4 { get; set; }
+        [Key(11)]
         public uint? Mmsi4 { get; set; }
 
         public BinaryAcknowledgeMessage()

--- a/src/AisParser/Messages/BinaryAddressedMessage.cs
+++ b/src/AisParser/Messages/BinaryAddressedMessage.cs
@@ -1,13 +1,22 @@
-﻿namespace AisParser.Messages
+﻿using MessagePack;
+namespace AisParser.Messages
 {
+    [MessagePackObject]
     public class BinaryAddressedMessage : AisMessage
     {
+        [Key(3)]
         public uint SequenceNumber { get; set; }
+        [Key(4)]
         public uint DestinationMmsi { get; set; }
+        [Key(5)]
         public bool RetransmitFlag { get; set; }
+        [Key(6)]
         public uint Spare { get; set; }
+        [Key(7)]
         public uint DesignatedAreaCode { get; set; }
+        [Key(8)]
         public uint FunctionalId { get; set; }
+        [Key(9)]
         public string Data { get; set; }
 
         public BinaryAddressedMessage()

--- a/src/AisParser/Messages/BinaryBroadcastMessage.cs
+++ b/src/AisParser/Messages/BinaryBroadcastMessage.cs
@@ -1,10 +1,16 @@
-﻿namespace AisParser.Messages
+﻿using MessagePack;
+namespace AisParser.Messages
 {
+    [MessagePackObject]
     public class BinaryBroadcastMessage : AisMessage
     {
+        [Key(3)]
         public uint Spare { get; set; }
+        [Key(4)]
         public uint DesignatedAreaCode { get; set; }
+        [Key(5)]
         public uint FunctionalId { get; set; }
+        [Key(6)]
         public string Data { get; set; }
 
         public BinaryBroadcastMessage()

--- a/src/AisParser/Messages/DataLinkManagementMessage.cs
+++ b/src/AisParser/Messages/DataLinkManagementMessage.cs
@@ -1,23 +1,42 @@
-﻿namespace AisParser.Messages
+﻿using MessagePack;
+namespace AisParser.Messages
 {
+    [MessagePackObject]
     public class DataLinkManagementMessage : AisMessage
     {
+        [Key(3)]
         public uint Spare { get; set; }
+        [Key(4)]
         public uint Offset1 { get; set; }
+        [Key(5)]
         public uint ReservedSlots1 { get; set; }
+        [Key(6)]
         public uint Timeout1 { get; set; }
+        [Key(7)]
         public uint Increment1 { get; set; }
+        [Key(8)]
         public uint Offset2 { get; set; }
+        [Key(9)]
         public uint ReservedSlots2 { get; set; }
+        [Key(10)]
         public uint Timeout2 { get; set; }
+        [Key(11)]
         public uint Increment2 { get; set; }
+        [Key(12)]
         public uint Offset3 { get; set; }
+        [Key(13)]
         public uint ReservedSlots3 { get; set; }
+        [Key(14)]
         public uint Timeout3 { get; set; }
+        [Key(15)]
         public uint Increment3 { get; set; }
+        [Key(16)]
         public uint Offset4 { get; set; }
+        [Key(17)]
         public uint ReservedSlots4 { get; set; }
+        [Key(18)]
         public uint Timeout4 { get; set; }
+        [Key(19)]
         public uint Increment4 { get; set; }
 
         public DataLinkManagementMessage()

--- a/src/AisParser/Messages/ExtendedClassBCsPositionReportMessage.cs
+++ b/src/AisParser/Messages/ExtendedClassBCsPositionReportMessage.cs
@@ -1,26 +1,48 @@
-﻿namespace AisParser.Messages
+﻿using MessagePack;
+namespace AisParser.Messages
 {
+    [MessagePackObject]
     public class ExtendedClassBCsPositionReportMessage : AisMessage
     {
+        [Key(3)]
         public uint Reserved { get; set; }
+        [Key(4)]
         public double SpeedOverGround { get; set; }
+        [Key(5)]
         public PositionAccuracy PositionAccuracy { get; set; }
+        [Key(6)]
         public double Longitude { get; set; }
+        [Key(7)]
         public double Latitude { get; set; }
+        [Key(8)]
         public double CourseOverGround { get; set; }
+        [Key(9)]
         public uint? TrueHeading { get; set; }
+        [Key(10)]
         public uint Timestamp { get; set; }
+        [Key(11)]
         public uint RegionalReserved { get; set; }
+        [Key(12)]
         public string Name { get; set; }
+        [Key(13)]
         public ShipType ShipType { get; set; }
+        [Key(14)]
         public uint DimensionToBow { get; set; }
+        [Key(15)]
         public uint DimensionToStern { get; set; }
+        [Key(16)]
         public uint DimensionToPort { get; set; }
+        [Key(17)]
         public uint DimensionToStarboard { get; set; }
+        [Key(18)]
         public PositionFixType PositionFixType { get; set; }
+        [Key(19)]
         public Raim Raim { get; set; }
+        [Key(20)]
         public bool DataTerminalReady { get; set; }
+        [Key(21)]
         public bool Assigned { get; set; }
+        [Key(22)]
         public uint Spare { get; set; }
 
         public ExtendedClassBCsPositionReportMessage()

--- a/src/AisParser/Messages/InterrogationMessage.cs
+++ b/src/AisParser/Messages/InterrogationMessage.cs
@@ -1,16 +1,26 @@
-﻿namespace AisParser.Messages
+﻿using MessagePack;
+namespace AisParser.Messages
 {
+    [MessagePackObject]
     public class InterrogationMessage: AisMessage
     {
+        [Key(3)]
         public uint InterrogatedMmsi { get; set; }
+        [Key(4)]
         public AisMessageType FirstMessageType { get; set; }
+        [Key(5)]
         public uint FirstSlotOffset { get; set; }
 
+        [Key(6)]
         public AisMessageType? SecondMessageType { get; set; }
+        [Key(7)]
         public uint? SecondSlotOffset { get; set; }
 
+        [Key(8)]
         public uint? SecondStationInterrogationMmsi { get; set; }
+        [Key(9)]
         public AisMessageType? SecondStationFirstMessageType { get; set; }
+        [Key(10)]
         public uint? SecondStationFirstSlotOffset { get; set; }
 
 

--- a/src/AisParser/Messages/PositionReportClassAMessageBase.cs
+++ b/src/AisParser/Messages/PositionReportClassAMessageBase.cs
@@ -55,5 +55,24 @@ namespace AisParser.Messages
             Raim = payload.ReadEnum<Raim>(148, 1);
             RadioStatus = payload.ReadUInt(149, 19);
         }
+
+        public override void Encode(Payload payload)
+        {
+            payload.WriteEnum(AisMessageType.PositionReportClassA, 6);
+            base.Encode(payload);
+            payload.WriteEnum<NavigationStatus>(NavigationStatus, 4);
+            payload.WriteRateOfTurn((int)RateOfTurn, 8);
+            payload.WriteSpeedOverGround(SpeedOverGround, 10);
+            payload.WriteEnum<PositionAccuracy>(PositionAccuracy, 1);
+            payload.WriteLongitude(Longitude, 28);
+            payload.WriteLatitude(Latitude, 27);
+            payload.WriteCourseOverGround(CourseOverGround, 12);
+            payload.WriteTrueHeading((uint)TrueHeading, 9);
+            payload.WriteUInt(Timestamp, 6);
+            payload.WriteEnum<ManeuverIndicator>(ManeuverIndicator, 2);
+            payload.WriteUInt(Spare, 3);
+            payload.WriteEnum<Raim>(Raim, 1);
+            payload.WriteUInt(RadioStatus, 19);
+        }
     }
 }

--- a/src/AisParser/Messages/PositionReportClassAMessageBase.cs
+++ b/src/AisParser/Messages/PositionReportClassAMessageBase.cs
@@ -1,19 +1,34 @@
+using MessagePack;
 namespace AisParser.Messages
 {
+    [MessagePackObject]
     public abstract class PositionReportClassAMessageBase : AisMessage
     {
+        [Key(3)]
         public NavigationStatus NavigationStatus { get; set; }
+        [Key(4)]
         public int? RateOfTurn { get; set; }
+        [Key(5)]
         public double SpeedOverGround { get; set; }
+        [Key(6)]
         public PositionAccuracy PositionAccuracy { get; set; }
+        [Key(7)]
         public double Longitude { get; set; }
+        [Key(8)]
         public double Latitude { get; set; }
+        [Key(9)]
         public double CourseOverGround { get; set; }
+        [Key(10)]
         public uint? TrueHeading { get; set; }
+        [Key(11)]
         public uint Timestamp { get; set; }
+        [Key(12)]
         public ManeuverIndicator ManeuverIndicator { get; set; }
+        [Key(13)]
         public uint Spare { get; set; }
+        [Key(14)]
         public Raim Raim { get; set; }
+        [Key(15)]
         public uint RadioStatus { get; set; }
 
         protected PositionReportClassAMessageBase(AisMessageType messageType)

--- a/src/AisParser/Messages/PositionReportForLongRangeApplicationsMessage.cs
+++ b/src/AisParser/Messages/PositionReportForLongRangeApplicationsMessage.cs
@@ -1,15 +1,26 @@
-﻿namespace AisParser.Messages
+﻿using MessagePack;
+namespace AisParser.Messages
 {
+    [MessagePackObject]
     public class PositionReportForLongRangeApplicationsMessage : AisMessage
     {
+        [Key(3)]
         public PositionAccuracy PositionAccuracy { get; set; }
+        [Key(4)]
         public Raim Raim { get; set; }
+        [Key(5)]
         public NavigationStatus NavigationStatus { get; set; }
+        [Key(6)]
         public double Longitude { get; set; }
+        [Key(7)]
         public double Latitude { get; set; }
+        [Key(8)]
         public double SpeedOverGround { get; set; }
+        [Key(9)]
         public double CourseOverGround { get; set; }
+        [Key(10)]
         public GnssPositionStatus GnssPositionStatus { get; set; }
+        [Key(11)]
         public uint Spare { get; set; }
 
         public PositionReportForLongRangeApplicationsMessage()

--- a/src/AisParser/Messages/SafetyRelatedAcknowledgementMessage.cs
+++ b/src/AisParser/Messages/SafetyRelatedAcknowledgementMessage.cs
@@ -1,15 +1,26 @@
-﻿namespace AisParser.Messages
+﻿using MessagePack;
+namespace AisParser.Messages
 {
+    [MessagePackObject]
     public class SafetyRelatedAcknowledgementMessage : AisMessage
     {
+        [Key(3)]
         public uint Spare { get; set; }
+        [Key(4)]
         public uint SequenceNumber1 { get; set; }
+        [Key(5)]
         public uint Mmsi1 { get; set; }
+        [Key(6)]
         public uint SequenceNumber2 { get; set; }
+        [Key(7)]
         public uint? Mmsi2 { get; set; }
+        [Key(8)]
         public uint SequenceNumber3 { get; set; }
+        [Key(9)]
         public uint? Mmsi3 { get; set; }
+        [Key(10)]
         public uint SequenceNumber4 { get; set; }
+        [Key(11)]
         public uint? Mmsi4 { get; set; }
 
         public SafetyRelatedAcknowledgementMessage()

--- a/src/AisParser/Messages/StandardClassBCsPositionReportMessage.cs
+++ b/src/AisParser/Messages/StandardClassBCsPositionReportMessage.cs
@@ -1,23 +1,42 @@
-﻿namespace AisParser.Messages
+﻿using MessagePack;
+namespace AisParser.Messages
 {
+    [MessagePackObject]
     public class StandardClassBCsPositionReportMessage : AisMessage
     {
+        [Key(3)]
         public uint Reserved { get; set; }
+        [Key(4)]
         public double SpeedOverGround { get; set; }
+        [Key(5)]
         public PositionAccuracy PositionAccuracy { get; set; }
+        [Key(6)]
         public double Longitude { get; set; }
+        [Key(7)]
         public double Latitude { get; set; }
+        [Key(8)]
         public double CourseOverGround { get; set; }
+        [Key(9)]
         public uint? TrueHeading { get; set; }
+        [Key(10)]
         public uint Timestamp { get; set; }
+        [Key(11)]
         public uint RegionalReserved { get; set; }
+        [Key(12)]
         public bool IsCsUnit { get; set; }
+        [Key(13)]
         public bool HasDisplay { get; set; }
+        [Key(14)]
         public bool HasDscCapability { get; set; }
+        [Key(15)]
         public bool Band { get; set; }
+        [Key(16)]
         public bool CanAcceptMessage22 { get; set; }
+        [Key(17)]
         public bool Assigned { get; set; }
+        [Key(18)]
         public Raim Raim { get; set; }
+        [Key(19)]
         public uint RadioStatus { get; set; }
 
         public StandardClassBCsPositionReportMessage()

--- a/src/AisParser/Messages/StandardSarAircraftPositionReportMessage.cs
+++ b/src/AisParser/Messages/StandardSarAircraftPositionReportMessage.cs
@@ -1,19 +1,34 @@
-﻿namespace AisParser.Messages
+﻿using MessagePack;
+namespace AisParser.Messages
 {
+    [MessagePackObject]
     public class StandardSarAircraftPositionReportMessage : AisMessage
     {
+        [Key(3)]
         public uint Altitude { get; set; }
+        [Key(4)]
         public uint SpeedOverGround { get; set; }
+        [Key(5)]
         public PositionAccuracy PositionAccuracy { get; set; }
+        [Key(6)]
         public double Longitude { get; set; }
+        [Key(7)]
         public double Latitude { get; set; }
+        [Key(8)]
         public double CourseOverGround { get; set; }
+        [Key(9)]
         public uint Timestamp { get; set; }
+        [Key(10)]
         public uint Reserved { get; set; }
+        [Key(11)]
         public bool DataTerminalReady { get; set; }
+        [Key(12)]
         public uint Spare { get; set; }
+        [Key(13)]
         public bool Assigned { get; set; }
+        [Key(14)]
         public Raim Raim { get; set; }
+        [Key(15)]
         public uint RadioStatus { get; set; }
 
         public StandardSarAircraftPositionReportMessage()

--- a/src/AisParser/Messages/StaticAndVoyageRelatedDataMessage.cs
+++ b/src/AisParser/Messages/StaticAndVoyageRelatedDataMessage.cs
@@ -1,24 +1,44 @@
-﻿namespace AisParser.Messages
+﻿using MessagePack;
+namespace AisParser.Messages
 {
+    [MessagePackObject]
     public class StaticAndVoyageRelatedDataMessage : AisMessage
     {
+        [Key(3)]
         public uint AisVersion { get; set; }
+        [Key(4)]
         public uint ImoNumber { get; set; }
+        [Key(5)]
         public string CallSign { get; set; }
+        [Key(6)]
         public string ShipName { get; set; }
+        [Key(7)]
         public ShipType ShipType { get; set; }
+        [Key(8)]
         public uint DimensionToBow { get; set; }
+        [Key(9)]
         public uint DimensionToStern { get; set; }
+        [Key(10)]
         public uint DimensionToPort { get; set; }
+        [Key(11)]
         public uint DimensionToStarboard { get; set; }
+        [Key(12)]
         public PositionFixType PositionFixType { get; set; }
+        [Key(13)]
         public uint EtaMonth { get; set; }
+        [Key(14)]
         public uint EtaDay { get; set; }
+        [Key(15)]
         public uint EtaHour { get; set; }
+        [Key(16)]
         public uint EtaMinute { get; set; }
+        [Key(17)]
         public double Draught { get; set; }
+        [Key(18)]
         public string Destination { get; set; }
+        [Key(19)]
         public bool DataTerminalReady { get; set; }
+        [Key(20)]
         public uint Spare { get; set; }
 
         public StaticAndVoyageRelatedDataMessage()

--- a/src/AisParser/Messages/StaticDataReportMessage.cs
+++ b/src/AisParser/Messages/StaticDataReportMessage.cs
@@ -1,7 +1,10 @@
-﻿namespace AisParser.Messages
+﻿using MessagePack;
+namespace AisParser.Messages
 {
+    [MessagePackObject]
     public class StaticDataReportMessage : AisMessage
     {
+        [Key(3)]
         public uint PartNumber { get; }
 
         protected StaticDataReportMessage()

--- a/src/AisParser/Messages/StaticDataReportPartAMessage.cs
+++ b/src/AisParser/Messages/StaticDataReportPartAMessage.cs
@@ -1,8 +1,12 @@
-﻿namespace AisParser.Messages
+﻿using MessagePack;
+namespace AisParser.Messages
 {
+    [MessagePackObject]
     public class StaticDataReportPartAMessage : StaticDataReportMessage
     {
+        [Key(4)]
         public string ShipName { get; set; }
+        [Key(5)]
         public uint Spare { get; set; }
 
         public StaticDataReportPartAMessage()

--- a/src/AisParser/Messages/StaticDataReportPartBMessage.cs
+++ b/src/AisParser/Messages/StaticDataReportPartBMessage.cs
@@ -1,17 +1,30 @@
-﻿namespace AisParser.Messages
+﻿using MessagePack;
+namespace AisParser.Messages
 {
+    [MessagePackObject]
     public class StaticDataReportPartBMessage : StaticDataReportMessage
     {
+        [Key(4)]
         public ShipType ShipType { get; set; }
+        [Key(5)]
         public string VendorId { get; set; }
+        [Key(6)]
         public uint UnitModelCode { get; set; }
+        [Key(7)]
         public uint SerialNumber { get; set; }
+        [Key(8)]
         public string CallSign { get; set; }
+        [Key(9)]
         public uint DimensionToBow { get; set; }
+        [Key(10)]
         public uint DimensionToStern { get; set; }
+        [Key(11)]
         public uint DimensionToPort { get; set; }
+        [Key(12)]
         public uint DimensionToStarboard { get; set; }
+        [Key(13)]
         public uint MothershipMmsi { get; set; }
+        [Key(14)]
         public uint Spare { get; set; }
 
         public StaticDataReportPartBMessage()

--- a/src/AisParser/Messages/UtcAndDateInquiryMessage.cs
+++ b/src/AisParser/Messages/UtcAndDateInquiryMessage.cs
@@ -1,9 +1,14 @@
-﻿namespace AisParser.Messages
+﻿using MessagePack;
+namespace AisParser.Messages
 {
+    [MessagePackObject]
     public class UtcAndDateInquiryMessage : AisMessage
     {
+        [Key(3)]
         public uint Spare1 { get; set; }
+        [Key(4)]
         public uint DestinationMmsi { get; set; }
+        [Key(5)]
         public uint Spare2 { get; set; }
 
         public UtcAndDateInquiryMessage()

--- a/src/AisParser/Messages/UtcAndDateResponseMessage.cs
+++ b/src/AisParser/Messages/UtcAndDateResponseMessage.cs
@@ -1,19 +1,34 @@
-﻿namespace AisParser.Messages
+﻿using MessagePack;
+namespace AisParser.Messages
 {
+    [MessagePackObject]
     public class UtcAndDateResponseMessage : AisMessage
     {
+        [Key(3)]
         public uint Year { get; set; }
+        [Key(4)]
         public uint Month { get; set; }
+        [Key(5)]
         public uint Day { get; set; }
+        [Key(6)]
         public uint Hour { get; set; }
+        [Key(7)]
         public uint Minute { get; set; }
+        [Key(8)]
         public uint Second { get; set; }
+        [Key(9)]
         public PositionAccuracy PositionAccuracy { get; set; }
+        [Key(10)]
         public double Longitude { get; set; }
+        [Key(11)]
         public double Latitude { get; set; }
+        [Key(12)]
         public PositionFixType PositionFixType { get; set; }
+        [Key(13)]
         public uint Spare { get; set; }
+        [Key(14)]
         public Raim Raim { get; set; }
+        [Key(15)]
         public uint RadioStatus { get; set; }
 
         public UtcAndDateResponseMessage()

--- a/src/AisParser/Parser.cs
+++ b/src/AisParser/Parser.cs
@@ -72,8 +72,7 @@ namespace AisParser
             //Field 5: Radio Channel Code (A or B)
             //Field 6: Payload
             //Field 7: 6 bit Boundary Padding (Zero seems to always be OK)?
-
-
+            
             string sentenceType = "AIVDM";
             int countOfFragments = 1;
             int fragmentNumber = 1;
@@ -100,8 +99,8 @@ namespace AisParser
             sentence += ",";
             sentence += boundaryPadding.ToString("0");
 
-            var calculatedChecksum = CalculateChecksum(sentence);
-            sentence += "*" + calculatedChecksum.ToString("00");
+            var calculatedChecksum = GenerateChecksum(sentence);
+            sentence += "*" + calculatedChecksum;
 
             return sentence;
         }
@@ -138,6 +137,11 @@ namespace AisParser
             return _payloadDecoder.Decode(encodedPayload, numFillBits);
         }
 
+        public string GenerateChecksum(string sentence)
+        {
+            var checksum = CalculateChecksum(sentence);
+            return Convert.ToString(checksum, 16).ToUpper();
+        }
         public int ExtractChecksum(string sentence, int checksumIndex)
         {
             var checksum = sentence.Substring(checksumIndex + 1);

--- a/src/AisParser/Parser.cs
+++ b/src/AisParser/Parser.cs
@@ -9,18 +9,20 @@ namespace AisParser
     {
         private readonly PayloadDecoder _payloadDecoder;
         private readonly AisMessageFactory _messageFactory;
+        private readonly PayloadEncoder _payloadEncoder;
         private readonly IDictionary<int, string> _fragments = new ConcurrentDictionary<int, string>();
 
         public Parser()
-            : this(new PayloadDecoder(), new AisMessageFactory())
+            : this(new PayloadDecoder(), new AisMessageFactory(), new PayloadEncoder())
         {
             
         }
 
-        public Parser(PayloadDecoder payloadDecoder, AisMessageFactory messageFactory)
+        public Parser(PayloadDecoder payloadDecoder, AisMessageFactory messageFactory, PayloadEncoder payloadEncoder)
         {
             _payloadDecoder = payloadDecoder;
             _messageFactory = messageFactory;
+            _payloadEncoder = payloadEncoder;
         }
 
         public AisMessage Parse(string sentence)
@@ -58,13 +60,62 @@ namespace AisParser
             return payload == null ? null : _messageFactory.Create(payload);
         }
 
+        public string Parse<T>(T aisMessage) where T : AisMessage
+        {
+            string sentence = "";
+
+            // Example: !AIVDM,1,1,,A,B6CdCm0t3`tba35f@V9faHi7kP06,0*58
+            //Field 1: Sentence Type
+            //Field 2: Count Of Fragments
+            //Field 3: Fragment Number
+            //Field 4: Sequential Messages ID for multi-sentence messages (blank for none)
+            //Field 5: Radio Channel Code (A or B)
+            //Field 6: Payload
+            //Field 7: 6 bit Boundary Padding (Zero seems to always be OK)?
+
+
+            string sentenceType = "AIVDM";
+            int countOfFragments = 1;
+            int fragmentNumber = 1;
+            int sequentialMessageId = 0;
+            string radioChannel = "A";
+            int boundaryPadding = 0;
+
+            var payload = _messageFactory.Encode<T>(aisMessage);
+            var payloadEncoded = _payloadEncoder.EncodeSixBitAis(payload);
+
+            //Build the full sentence
+            sentence += "!";
+            sentence += sentenceType;
+            sentence += ",";
+            sentence += countOfFragments.ToString("0");
+            sentence += ",";
+            sentence += fragmentNumber.ToString("0");
+            sentence += ",";
+            if(sequentialMessageId != 0) sentence += sequentialMessageId.ToString("0");
+            sentence += ",";
+            sentence += radioChannel;
+            sentence += ",";
+            sentence += payloadEncoded;
+            sentence += ",";
+            sentence += boundaryPadding.ToString("0");
+
+            var calculatedChecksum = CalculateChecksum(sentence);
+            sentence += "*" + calculatedChecksum.ToString("00");
+
+            return sentence;
+        }
+
         private Payload DecodePayload(string encodedPayload, string[] sentenceParts)
         {
             var numFragments = Convert.ToInt32(sentenceParts[1]);
             var numFillBits = Convert.ToInt32(sentenceParts[6]);
 
-            if (numFragments == 1) 
-                return _payloadDecoder.Decode(encodedPayload, numFillBits);
+            if (numFragments == 1)
+            {
+                var decoded = _payloadDecoder.Decode(encodedPayload, numFillBits);
+                return decoded;
+            }
 
             var fragmentNumber = Convert.ToInt32(sentenceParts[2]);
             var messageId = Convert.ToInt32(sentenceParts[3]);

--- a/src/AisParser/Payload.cs
+++ b/src/AisParser/Payload.cs
@@ -15,15 +15,20 @@ namespace AisParser
             MessageType = ReadEnum<AisMessageType>(0, 6);
         }
 
-        public string RawValue { get; }
+        public string RawValue; // { get; }
 
-        public AisMessageType MessageType { get; }
+        public AisMessageType MessageType; // { get; }
 
         public T ReadEnum<T>(int startIndex, int length) where T : Enum
         {
             var bitValue = Substring(startIndex, length);
             var value = Convert.ToUInt32(bitValue, 2);
             return (T) Enum.ToObject(typeof(T), value);
+        }
+
+        public void WriteEnum<T>(T var, int length) where T : Enum
+        {
+            WriteUInt(Convert.ToUInt32(var), length);
         }
 
         public AisMessageType? ReadNullableMessageType(int startIndex, int length)
@@ -39,6 +44,10 @@ namespace AisParser
         {
             var bitValue = Substring(startIndex, length);
             return Convert.ToUInt32(bitValue, 2);
+        }
+        public void WriteUInt(uint var, int length)
+        {
+            RawValue += Convert.ToString(var, 2).PadLeft(length, '0');
         }
 
         public uint? ReadNullableUInt(int startIndex, int length)
@@ -61,7 +70,11 @@ namespace AisParser
                 return null;
             return value;
         }
-
+        public void WriteMmsi(uint var, int length)
+        {
+            WriteUInt(var,length);
+        }
+        
         public int ReadInt(int startIndex, int length)
         {
             var bitValue = Substring(startIndex, length);
@@ -71,11 +84,19 @@ namespace AisParser
 
             return result;
         }
+        public void WriteInt(int var, int length)
+        {
+            RawValue += Convert.ToString(var, 2).PadLeft(length, '0');
+        }
 
         public double ReadUnsignedDouble(int startIndex, int length)
         {
             var bitValue = Substring(startIndex, length);
             return Convert.ToUInt32(bitValue, 2);
+        }
+        public void WriteUnsignedDouble(double var, int length)
+        {
+            RawValue += Convert.ToString((UInt32)var, 2).PadLeft(length, '0');
         }
 
         public double ReadDouble(int startIndex, int length)
@@ -88,11 +109,22 @@ namespace AisParser
 
             return result;
         }
+        public void WriteDouble(double var, int length)
+        {
+            if (var < 0)
+                var = var + Math.Pow(2, length);
+
+            RawValue += Convert.ToString((UInt32)var, 2).PadLeft(length, '0');
+        }
 
         public int? ReadRateOfTurn(int startIndex, int length)
         {
             var rateOfTurn = ReadInt(startIndex, length);
             return rateOfTurn == -256 ? null : new int?(rateOfTurn);
+        }
+        public void WriteRateOfTurn(int var, int length)
+        {
+            WriteInt(var, length);
         }
 
         public uint? ReadTrueHeading(int startIndex, int length)
@@ -100,25 +132,43 @@ namespace AisParser
             var trueHeading = ReadUInt(startIndex, length);
             return trueHeading == 511 ? null : new uint?(trueHeading);
         }
-
+        public void WriteTrueHeading(uint var, int length)
+        {
+            WriteUInt(var, length);
+        }
         public double ReadLongitude(int startIndex, int length)
         {
             return ReadDouble(startIndex, length) / 600000;
+        }
+        public void WriteLongitude(double var, int length)
+        {
+            WriteDouble(var * 600000, length);
         }
 
         public double ReadLatitude(int startIndex, int length)
         {
             return ReadDouble(startIndex, length) / 600000;
         }
+        public void WriteLatitude(double var, int length)
+        {
+            WriteDouble(var * 600000, length);
+        }
 
         public double ReadSpeedOverGround(int startIndex, int length)
         {
             return ReadUnsignedDouble(startIndex, length) / 10;
         }
-
+        public void WriteSpeedOverGround(double var, int length)
+        {
+            WriteUnsignedDouble(var * 10, length);
+        }
         public double ReadCourseOverGround(int startIndex, int length)
         {
             return ReadUnsignedDouble(startIndex, length) / 10;
+        }
+        public void WriteCourseOverGround(double var, int length)
+        {
+            WriteUnsignedDouble(var * 10, length);
         }
 
         public string ReadString(int startIndex, int length)
@@ -139,10 +189,18 @@ namespace AisParser
 
             return value.Trim();
         }
+        /*public void WriteString(string var, int length)
+        {
+            RawValue += Convert.ToString(var, 2).PadLeft(length, '0');
+        }*/
 
         public double ReadDraught(int startIndex, int length)
         {
             return ReadUnsignedDouble(startIndex, length) / 10;
+        }
+        public void WriteDraught(double var, int length)
+        {
+            WriteUnsignedDouble(var * 10, length);
         }
 
         public bool ReadDataTerminalReady(int startIndex, int length)
@@ -155,6 +213,10 @@ namespace AisParser
         {
             var bitValue = Substring(startIndex, length);
             return Convert.ToInt32(bitValue) == 1;
+        }
+        public void WriteBoolean(bool var, int length)
+        {
+            RawValue += var.ToString();
         }
 
         private string Substring(int startIndex, int length)

--- a/src/AisParser/PayloadDecoder.cs
+++ b/src/AisParser/PayloadDecoder.cs
@@ -33,5 +33,6 @@ namespace AisParser
 
             return new Payload(payload.ToString());
         }
+
     }
 }

--- a/src/AisParser/PayloadEncoder.cs
+++ b/src/AisParser/PayloadEncoder.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Text;
+
+namespace AisParser
+{
+    public class PayloadEncoder
+    {
+        public string EncodeSixBitAis(Payload payload)
+        {
+            //Consume each 6 bits and making them 8 bits, with some value shifts
+            var value = payload.RawValue;
+            if (String.IsNullOrEmpty(value))
+                return value;
+
+            string ret = "";
+
+            for (int i = 0; i < value.Length / 6; ++i)
+            {
+                var b = value.Substring(6 * i, 6).PadLeft(8, '0');
+                var c = (byte)ConvertBitsToChar(b);
+
+                if (c < 40)
+                    c += 48;
+                else
+                    c += 56;
+
+                ret += Convert.ToChar(c);
+            }
+
+            return ret;
+        }
+
+        private static Char ConvertBitsToChar(String value)
+        {
+            int result = 0;
+
+            foreach (Char ch in value)
+                result = result * 2 + ch - '0';
+
+            return (Char)result;
+        }
+
+    }
+}

--- a/test/AisParserTests/AisParserTests.csproj
+++ b/test/AisParserTests/AisParserTests.csproj
@@ -1,9 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net4.6.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <ApplicationIcon />
+
+    <OutputType>Library</OutputType>
+
+    <StartupObject />
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/AisParserTests/AisParserTests.csproj
+++ b/test/AisParserTests/AisParserTests.csproj
@@ -1,15 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net4.6.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
-
-    <ApplicationIcon />
-
-    <OutputType>Library</OutputType>
-
-    <StartupObject />
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This update allows re-encoding a decoded class into a binary AIS message with headers and checksum calculations. There may be some additional refactoring to look at to define options like channel A/B in the message. We are using this to generate an AIS stream to display MMSI and location. Overall there should be no breaking changes at all, as these are new functions that do not utilize the decoding framework.